### PR TITLE
Refactor tests

### DIFF
--- a/tests/LazyRobotLoaderClassFinderTest.php
+++ b/tests/LazyRobotLoaderClassFinderTest.php
@@ -16,7 +16,7 @@ class LazyRobotLoaderClassFinderTest extends \PHPUnit\Framework\TestCase
 			->setMethods(['rebuild'])
 			->getMock();
 		$robotLoader
-			->expects($this->once())
+			->expects(self::once())
 			->method('rebuild');
 
 		$lazyClassFinder = new LazyRobotLoaderClassFinder($robotLoader);

--- a/tests/RobotLoaderClassFinderTest.php
+++ b/tests/RobotLoaderClassFinderTest.php
@@ -4,54 +4,65 @@ declare(strict_types = 1);
 
 namespace Consistence\ClassFinder\RobotLoader;
 
+use Generator;
 use Nette\Loaders\RobotLoader;
 use PHPUnit\Framework\Assert;
 
 class RobotLoaderClassFinderTest extends \PHPUnit\Framework\TestCase
 {
 
-	public function testFindClass(): void
+	/**
+	 * @return mixed[][]|\Generator
+	 */
+	public function findByInterfaceDataProvider(): Generator
 	{
-		$classList = array_values($this->getRobotLoaderClassFinder()->findByInterface(ExtendingClass::class));
-
-		Assert::assertContains(ExtendingClass::class, $classList);
-		Assert::assertCount(1, $classList);
-	}
-
-	public function testFindClassAndChildren(): void
-	{
-		$classList = array_values($this->getRobotLoaderClassFinder()->findByInterface(BaseClass::class));
-		sort($classList);
-
-		$expected = [
-			BaseClass::class,
-			ExtendingClass::class,
+		yield 'class' => [
+			'interfaceName' => ExtendingClass::class,
+			'expectedClassList' => [
+				ExtendingClass::class,
+			],
 		];
-
-		Assert::assertEquals($expected, $classList);
-	}
-
-	public function testFindInterface(): void
-	{
-		$classList = array_values($this->getRobotLoaderClassFinder()->findByInterface(NotImplementedInterface::class));
-
-		Assert::assertContains(NotImplementedInterface::class, $classList);
-		Assert::assertCount(1, $classList);
-	}
-
-	public function testFindInterfaceAndImplementations(): void
-	{
-		$classList = array_values($this->getRobotLoaderClassFinder()->findByInterface(BaseInterface::class));
-		sort($classList);
-
-		$expected = [
-			BaseClass::class,
-			BaseInterface::class,
-			ExtendingClass::class,
-			ExtendingInterface::class,
+		yield 'class and children' => [
+			'interfaceName' => BaseClass::class,
+			'expectedClassList' => [
+				BaseClass::class,
+				ExtendingClass::class,
+			],
 		];
+		yield 'not implemented interface' => [
+			'interfaceName' => NotImplementedInterface::class,
+			'expectedClassList' => [
+				NotImplementedInterface::class,
+			],
+		];
+		yield 'interface and implementations' => [
+			'interfaceName' => BaseInterface::class,
+			'expectedClassList' => [
+				BaseClass::class,
+				BaseInterface::class,
+				ExtendingClass::class,
+				ExtendingInterface::class,
+			],
+		];
+	}
 
-		Assert::assertEquals($expected, $classList);
+	/**
+	 * @dataProvider findByInterfaceDataProvider
+	 *
+	 * @param string $interfaceName
+	 * @param string[] $expectedClassList
+	 */
+	public function testFindByInterface(
+		string $interfaceName,
+		array $expectedClassList
+	): void
+	{
+		$classList = array_values($this->getRobotLoaderClassFinder()->findByInterface($interfaceName));
+
+		foreach ($expectedClassList as $expectedClass) {
+			Assert::assertContains($expectedClass, $classList);
+		}
+		Assert::assertCount(count($expectedClassList), $classList);
 	}
 
 	private function getRobotLoaderClassFinder(): RobotLoaderClassFinder

--- a/tests/RobotLoaderClassFinderTest.php
+++ b/tests/RobotLoaderClassFinderTest.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Consistence\ClassFinder\RobotLoader;
 
 use Nette\Loaders\RobotLoader;
+use PHPUnit\Framework\Assert;
 
 class RobotLoaderClassFinderTest extends \PHPUnit\Framework\TestCase
 {
@@ -13,8 +14,8 @@ class RobotLoaderClassFinderTest extends \PHPUnit\Framework\TestCase
 	{
 		$classList = array_values($this->getRobotLoaderClassFinder()->findByInterface(ExtendingClass::class));
 
-		$this->assertContains(ExtendingClass::class, $classList);
-		$this->assertCount(1, $classList);
+		Assert::assertContains(ExtendingClass::class, $classList);
+		Assert::assertCount(1, $classList);
 	}
 
 	public function testFindClassAndChildren(): void
@@ -27,15 +28,15 @@ class RobotLoaderClassFinderTest extends \PHPUnit\Framework\TestCase
 			ExtendingClass::class,
 		];
 
-		$this->assertEquals($expected, $classList);
+		Assert::assertEquals($expected, $classList);
 	}
 
 	public function testFindInterface(): void
 	{
 		$classList = array_values($this->getRobotLoaderClassFinder()->findByInterface(NotImplementedInterface::class));
 
-		$this->assertContains(NotImplementedInterface::class, $classList);
-		$this->assertCount(1, $classList);
+		Assert::assertContains(NotImplementedInterface::class, $classList);
+		Assert::assertCount(1, $classList);
 	}
 
 	public function testFindInterfaceAndImplementations(): void
@@ -50,7 +51,7 @@ class RobotLoaderClassFinderTest extends \PHPUnit\Framework\TestCase
 			ExtendingInterface::class,
 		];
 
-		$this->assertEquals($expected, $classList);
+		Assert::assertEquals($expected, $classList);
 	}
 
 	private function getRobotLoaderClassFinder(): RobotLoaderClassFinder


### PR DESCRIPTION
- [x] stop calling static methods in tests as non-static
- [x] use assertSame() where assertEquals() is not explicitly needed
- [x] use assertCount() after assertContains() for array comparison
- [x] add missing Assert::fail() in try+catch blocks when expecting exceptions
- [x] unify Assert::fail() message
- [x] replace Consistence\TestCase::ok() with expectNotToPerformAssertions()
- [x] use try+catch+fail when expecting exceptions with properties
- [x] rename data providers to singular where applicable
- [x] use DataProvider suffix for data providers
- [x] change data provider return type from array to Generator
- [x] declare data provider values on separate lines
- [x] isolate data provider cases using Closures
- [x] name data provider values
- [x] name data provider cases
- [x] extract multiple cases from test methods to data providers
- [x] remove unnecessary private methods for creating mocks